### PR TITLE
Added call to stop channel on wallop server.

### DIFF
--- a/source/videoScreen.brs
+++ b/source/videoScreen.brs
@@ -28,6 +28,7 @@ Function displayVideo(channel As string, args As Dynamic)
         if type(msg) = "roVideoScreenEvent"
             if msg.isScreenClosed() then 'ScreenClosed event
                 print "Closing video screen"
+                stopChannel(channel)
                 exit while
             else if msg.isPlaybackPosition() then
                 nowpos = msg.GetIndex()

--- a/source/wallopClient.brs
+++ b/source/wallopClient.brs
@@ -61,6 +61,13 @@ function tuneChannel(channelNum As string)
 
 End Function
 
+' Tells Wallop to stop the specified channel number.
+function stopChannel(channelNum As string)
+    request = CreateObject("roUrlTransfer")
+    url = getBaseWallopUrl() + "/channels/" + channelNum + "/stop"
+    request.SetUrl(url)
+    request.PostFromString("")
+End Function
 
 ' Simple helper method for building the Wallop server 
 ' path defined in the user settings


### PR DESCRIPTION
Stops the channel on the server to allow ffmpeg to be closed and the tuner to be released. 

I'm also working on a python server similar to wallop for working with the HDTC-2US.

https://github.com/themacks/ply
